### PR TITLE
[docs] Added details on how to use the engflowapis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # EngFlow APIs
 
-This repository contains the gRPC service definitions for public EngFlow APIs;
-the **authentication API**, **notification queue API** and the **eventstore API**.
+This repository contains the gRPC service definitions for public EngFlow APIs:
+
+- **authentication API**
+- **notification queue API**
+- **eventstore API**.
 This repository intentionally does not provide generated code for any languages
 to keep it free of clutter. In other words,  it only provides
 [protocol buffers](https://developers.google.com/protocol-buffers) definitions.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains the gRPC service definitions for public EngFlow APIs:
 - **authentication API**
 - **notification queue API**
 - **eventstore API**.
+
 This repository intentionally does not provide generated code for any languages
 to keep it free of clutter. In other words,  it only provides
 [protocol buffers](https://developers.google.com/protocol-buffers) definitions.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ which automatically fetches the latest stable version of Bazel by default.
 
 To build all libraries run:
 
-```
+```bash
 bazel build //...
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,91 @@
 # EngFlow APIs
 
-This repository contains the gRPC service definitions for public EngFlow APIs.
-
+This repository contains the gRPC service definitions for public EngFlow APIs;
+the **authentication API**, **notification queue API** and the **eventstore API**.
 This repository intentionally does not provide generated code for any languages
-to keep it free of clutter.
+to keep it free of clutter. In other words,  it only provides
+[protocol buffers](https://developers.google.com/protocol-buffers) definitions.
 
 
 ## Building
 
-Use [Bazel](https://bazel.build/) >= 5.x.
+In order to build the library you should count with a [Bazel](https://bazel.build/)
+installation with version **>= 5.x**. 
+Older versions of Bazel may work as well, but are not officially supported.
+If you do not count with Bazel in your system,
+we recommend to install [bazelisk](https://github.com/bazelbuild/bazelisk) which uses by default the last stable
+version of the building system.
 
-> Note: older versions of Bazel may work as well, but are not officially supported.
-
-First, [install bazel](https://docs.bazel.build/versions/master/install.html).
-
-To build all libraries:
+To build all libraries run:
 
 ```
 bazel build //...
 ```
+
+## Using the APIs in your (bazel) project
+
+In order to integrate the `engflowapis` into your Bazel project, you should
+include it using one of two bazel methods; 
+`git_repository` or `http_archive`.
+
+### Download with git_repository
+
+Include the `engflowapis` by adding the following instruction to your `WORKSPACE`
+file in your root directory:
+
+```
+...
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+...
+git_repository(
+    name = "com_engflow_engflowapis",
+    branch = "main",
+    remote = "https://github.com/EngFlow/engflowapis",
+)
+```
+
+This command will fetch a fresh copy of the repository and link it with 
+the name `com_engflow_engflowapis`. Be aware that this command downloads all
+history from the repository, but you can configure it to fetch only 
+a given commit (see [git_repository](https://bazel.build/rules/lib/repo/git) for more info).
+
+### Download with http_archive
+
+Alternatively, you may use a specific commit from GitHub and then store and reference
+it in any storage service. To do so, you may download a zip file using a
+commit sha and with the GitHub API:
+
+```
+wget "https://github.com/EngFlow/engflowapis/archive/47aa858b498da13e7863356aaef9c6d05da0a7f2.zip"
+```
+
+This will download the repository in its commit sha `47aa858b498da13e7863356aaef9c6d05da0a7f2`.
+The repository may be used locally using Bazel's [local_repository](https://bazel.build/reference/be/workspace#local_repository).
+However, it is recommended to store the file in a fast storage service in such a way
+that you can use `http_archive` like this
+
+
+```
+...
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+...
+http_archive(
+    name = "com_engflow_engflowapis",
+    sha256 = "a04a2d2a978355c85dff8b1018d12a8e0a1e6692add9de716fd4d1b7aa1e2a0d",
+    strip_prefix = "engflowapis-47aa858b498da13e7863356aaef9c6d05da0a7f2",
+    urls = [
+        "https://storage.googleapis.com/engflow-tools-public/engflowapis-47aa858b498da13e7863356aaef9c6d05da0a7f2.zip",
+        "https://github.com/EngFlow/engflowapis/archive/47aa858b498da13e7863356aaef9c6d05da0a7f2.zip",
+    ],
+)
+```
+
+This command will fetch a fresh copy of the repository and link it with
+the name `com_engflow_engflowapis`.
+
+### Check out a full example
+
+You should use the protocol buffer definitions from the `engflowapis`. In here,
+you need to include building blocks such as `protocol buffer` tools and `googleapis` definitions.
+Check out the full working [engflow example](https://github.com/EngFlow/example), 
+that uses the notification queue and event store APIs, to get a better understanding.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the gRPC service definitions for public EngFlow APIs:
 
 - **authentication API**
 - **notification queue API**
-- **eventstore API**.
+- **eventstore API**
 
 This repository intentionally does not provide generated code for any languages
 to keep it free of clutter. In other words,  it only provides
@@ -30,24 +30,8 @@ bazel build //...
 In order to integrate the `engflowapis` into your Bazel project, you should
 include it using `http_archive`.
 
-We recommend to download a specific commit from GitHub and then store and reference
-it in any storage service. To do so, you may download a repository `zip` file using a
-commit sha:
-
-```bash
-wget "https://github.com/EngFlow/engflowapis/archive/47aa858b498da13e7863356aaef9c6d05da0a7f2.zip"
-```
-
-This, for instance, downloads the repository in its commit sha `47aa858b498da13e7863356aaef9c6d05da0a7f2`.
-The repository may be used locally using Bazel's [local_repository](https://bazel.build/reference/be/workspace#local_repository).
-However, it is recommended to store the file in a highly available storage service in such a way
-that you can use `http_archive` like this
-
-
-```
-...
+```bzl
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-...
 http_archive(
     name = "com_engflow_engflowapis",
     sha256 = "a04a2d2a978355c85dff8b1018d12a8e0a1e6692add9de716fd4d1b7aa1e2a0d",

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ to keep it free of clutter. In other words,  it only provides
 
 ## Building
 
-In order to build the library you should count with a [Bazel](https://bazel.build/)
-installation with version **>= 5.x**. 
+Use [Bazel](https://bazel.build/) 5.x (or higher) to build the library.
 Older versions of Bazel may work as well, but are not officially supported.
-If you do not count with Bazel in your system,
-we recommend to install [bazelisk](https://github.com/bazelbuild/bazelisk) which uses by default the last stable
-version of the building system.
+If you do not have Bazel installed already, we recommend installing
+[bazelisk](https://github.com/bazelbuild/bazelisk),
+which automatically fetches the latest stable version of Bazel by default.
 
 To build all libraries run:
 
@@ -22,34 +21,10 @@ To build all libraries run:
 bazel build //...
 ```
 
-## Using the APIs in your (bazel) project
+## Using the APIs in your Bazel project
 
 In order to integrate the `engflowapis` into your Bazel project, you should
-include it using one of two bazel methods; 
-`git_repository` or `http_archive`.
-
-### Download with git_repository
-
-Include the `engflowapis` by adding the following instruction to your `WORKSPACE`
-file in your root directory:
-
-```
-...
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-...
-git_repository(
-    name = "com_engflow_engflowapis",
-    branch = "main",
-    remote = "https://github.com/EngFlow/engflowapis",
-)
-```
-
-This command will fetch a fresh copy of the repository and link it with 
-the name `com_engflow_engflowapis`. Be aware that this command downloads all
-history from the repository, but you can configure it to fetch only 
-a given commit (see [git_repository](https://bazel.build/rules/lib/repo/git) for more info).
-
-### Download with http_archive
+include it using `http_archive`.
 
 Alternatively, you may use a specific commit from GitHub and then store and reference
 it in any storage service. To do so, you may download a zip file using a
@@ -88,4 +63,6 @@ the name `com_engflow_engflowapis`.
 You should use the protocol buffer definitions from the `engflowapis`. In here,
 you need to include building blocks such as `protocol buffer` tools and `googleapis` definitions.
 Check out the full working [engflow example](https://github.com/EngFlow/example), 
-that uses the notification queue and event store APIs, to get a better understanding.
+that uses the 
+[notification queue and event store APIs](https://github.com/EngFlow/example/tree/main/java/com/engflow/notificationqueue),
+to get a better understanding.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We recommend to download a specific commit from GitHub and then store and refere
 it in any storage service. To do so, you may download a repository `zip` file using a
 commit sha:
 
-```
+```bash
 wget "https://github.com/EngFlow/engflowapis/archive/47aa858b498da13e7863356aaef9c6d05da0a7f2.zip"
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ bazel build //...
 In order to integrate the `engflowapis` into your Bazel project, you should
 include it using `http_archive`.
 
-Alternatively, you may use a specific commit from GitHub and then store and reference
-it in any storage service. To do so, you may download a zip file using a
-commit sha and with the GitHub API:
+We recommend to download a specific commit from GitHub and then store and reference
+it in any storage service. To do so, you may download a repository `zip` file using a
+commit sha:
 
 ```
 wget "https://github.com/EngFlow/engflowapis/archive/47aa858b498da13e7863356aaef9c6d05da0a7f2.zip"
 ```
 
-This will download the repository in its commit sha `47aa858b498da13e7863356aaef9c6d05da0a7f2`.
+This, for instance, downloads the repository in its commit sha `47aa858b498da13e7863356aaef9c6d05da0a7f2`.
 The repository may be used locally using Bazel's [local_repository](https://bazel.build/reference/be/workspace#local_repository).
-However, it is recommended to store the file in a fast storage service in such a way
+However, it is recommended to store the file in a highly available storage service in such a way
 that you can use `http_archive` like this
 
 


### PR DESCRIPTION
This is the begging on how to use the repository. Nonetheless, we will add some sections explaining what does each of the
APIs do. In particular a section for

- [auth](https://github.com/EngFlow/engflowapis/tree/main/engflow/auth): What does this do?
- [eventstore/v1](https://github.com/EngFlow/engflowapis/tree/main/engflow/eventstore/v1): What does this do?
- [notification/v1](https://github.com/EngFlow/engflowapis/tree/main/engflow/notification/v1): What does this do?

@Yannic those sections need your contribution.
I believe we need to document in such a way that any customer with any language can use the apis without going to any other repository.