### PR TITLE
chore: applies native-proto buildifier fixes

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_descriptor_set")
 
 exports_files(

--- a/engflow/BUILD
+++ b/engflow/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "engflow",
     visibility = ["//visibility:public"],

--- a/engflow/api/BUILD
+++ b/engflow/api/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "api",
     visibility = ["//visibility:public"],

--- a/engflow/auth/BUILD
+++ b/engflow/auth/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "auth",
     visibility = ["//visibility:public"],

--- a/engflow/cluster/BUILD
+++ b/engflow/cluster/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "cluster",
     visibility = ["//visibility:public"],

--- a/engflow/cluster/v1/BUILD
+++ b/engflow/cluster/v1/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "v1",
     visibility = ["//visibility:public"],

--- a/engflow/eventstore/BUILD
+++ b/engflow/eventstore/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "eventstore",
     visibility = ["//visibility:public"],

--- a/engflow/eventstore/v1/BUILD
+++ b/engflow/eventstore/v1/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "v1",
     visibility = ["//visibility:public"],

--- a/engflow/iam/BUILD
+++ b/engflow/iam/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "iam",
     visibility = ["//visibility:public"],

--- a/engflow/iam/authentication/BUILD
+++ b/engflow/iam/authentication/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "authentication",
     visibility = ["//visibility:public"],

--- a/engflow/iam/authentication/v1/BUILD
+++ b/engflow/iam/authentication/v1/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "v1",
     visibility = ["//visibility:public"],

--- a/engflow/iam/v1/BUILD
+++ b/engflow/iam/v1/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "v1",
     visibility = ["//visibility:public"],

--- a/engflow/notification/BUILD
+++ b/engflow/notification/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "notification",
     visibility = ["//visibility:public"],

--- a/engflow/notification/v1/BUILD
+++ b/engflow/notification/v1/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "v1",
     visibility = ["//visibility:public"],

--- a/engflow/resourceusage/BUILD
+++ b/engflow/resourceusage/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "resourceusage",
     visibility = ["//visibility:public"],

--- a/engflow/resourceusage/v1/BUILD
+++ b/engflow/resourceusage/v1/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "v1",
     visibility = ["//visibility:public"],

--- a/engflow/resultstore/BUILD
+++ b/engflow/resultstore/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "resultstore",
     visibility = ["//visibility:public"],

--- a/engflow/resultstore/v1/BUILD
+++ b/engflow/resultstore/v1/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "v1",
     visibility = ["//visibility:public"],

--- a/engflow/type/BUILD
+++ b/engflow/type/BUILD
@@ -1,3 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 proto_library(
     name = "type",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Applies fixes from https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#proto_library-rule-should-be-loaded-from-starlark.