### PR TITLE
Prepare `@engflowapis-java` for BCR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,14 @@ jobs:
           chmod +x "${RUNNER_TEMP}/buildozer"
 
           # 2. Update `MODULE.bazel` and commit.
-          "${RUNNER_TEMP}/buildozer" "set version ${VERSION}" "//MODULE.bazel:engflowapis"
-          git add "MODULE.bazel"
+          "${RUNNER_TEMP}/buildozer" \
+              "set version ${VERSION}" \
+            "//MODULE.bazel:engflowapis" \
+            "//java/MODULE.bazel:engflowapis-java" \
+            "//java/MODULE.bazel:engflowapis"
+          git add \
+            "MODULE.bazel" \
+            "java/MODULE.bazel"
           git commit -m "Release ${VERSION}"
 
           # 3. Push release tag.

--- a/java/MODULE.bazel
+++ b/java/MODULE.bazel
@@ -1,5 +1,5 @@
 module(
-    name = "engflowapis_java",
+    name = "engflowapis-java",
     version = "HEAD",  # Automatically updated by release pipeline.
 )
 


### PR DESCRIPTION
This change updates the release script to also bump the version of `@engflowapis-java` and `@engflowapis` in `//java:MODULE.bazel` so released versions are in lock-step with each other.