### PR TITLE
[ci] Use public email of bot account

### DIFF
--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -28,7 +28,7 @@ jobs:
       attest: false
       # use https://github.com/engflow-automation-public as public-facing identity in pushes to BCR via .github/workflows/publish-to-bcr.yaml
       author_name: "EngFlow Inc."
-      author_email: "212036618+engflow-automation-public@users.noreply.github.com"
+      author_email: "engflow-github-automation+public@engflow.com"
     permissions:
       attestations: write
       contents: write


### PR DESCRIPTION
Otherwise, Google CLA checks can't find that the bot is covered by CLA.